### PR TITLE
Added nrm container; Added nrm-k3s plugin

### DIFF
--- a/ansible/kubernetes/nrm-k3s.yaml
+++ b/ansible/kubernetes/nrm-k3s.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nrm-k3s
+  name: nrm-k3s
+spec:
+  selector:
+    matchLabels:
+      app: nrm-k3s
+  template:
+    metadata:
+      labels:
+        app: nrm-k3s
+    spec:
+      serviceAccountName: nrm-k3s
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      containers:
+        - name: nrm-k3s
+          image: gemblerz/nrm:0.1.0
+          imagePullPolicy: Always
+          command: ["python3"]
+          args:
+          - /app/nrm-k3s.py
+          - --namespace
+          - workload
+          env:
+          - name: NRM_URI
+            value: "tcp://nrm"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 50Mi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nrm-k3s
+rules:
+  - apiGroups: ["", "batch", "metrics.k8s.io"] # "" indicates the core API group
+    resources:
+      [
+        "namespaces",
+        "configmaps",
+        "services",
+        "jobs",
+        "nodes",
+        "pods",
+        "pods/log",
+        "secrets",
+        "events",
+      ]
+    verbs: ["create", "get", "watch", "list", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nrm-k3s
+roleRef:
+  kind: ClusterRole
+  name: nrm-k3s
+  apiGroup: rbac.authorization.k8s.io
+  # `edit` is a built-in cluster role. more info about these can be found here:
+  # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+subjects:
+  - kind: ServiceAccount
+    name: nrm-k3s
+    namespace: charon
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nrm-k3s

--- a/ansible/kubernetes/nrm.yaml
+++ b/ansible/kubernetes/nrm.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nrm
+  name: nrm
+spec:
+  selector:
+    matchLabels:
+      app: nrm
+  template:
+    metadata:
+      labels:
+        app: nrm
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      containers:
+        - name: nrm
+          image: gemblerz/nrm:0.1.0
+          imagePullPolicy: Always
+          command: ["nrmd"]
+          args:
+          - --uri
+          - "tcp://0.0.0.0"
+          - --verbose
+          ports:
+          - name: pub
+            containerPort: 2345
+            hostPort: 2345
+          - name: rpc
+            containerPort: 3456
+            hostPort: 3456
+          resources:
+            requests:
+              cpu: 250m
+              memory: 50Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nrm
+spec:
+  ports:
+    - name: pub
+      port: 2345
+      targetPort: pub
+    - name: rpc
+      port: 3456
+      targetPort: rpc
+  selector:
+    app: nrm
+  type: ClusterIP

--- a/src/nrm_docker/Dockerfile
+++ b/src/nrm_docker/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:22.04
+
+RUN apt-get update \
+  && apt-get install -y \
+  git \
+  software-properties-common \
+  gcc \
+  nano \
+  make \
+  autoconf \
+  automake \
+  libtool \
+  pkg-config \
+  libzmq3-dev \
+  libzmq5 \
+  libczmq-dev \
+  libczmq4 \
+  libprotobuf-c-dev \
+  protobuf-c-compiler \
+  libjansson-dev \
+  libjansson4 \
+  check \
+  libhwloc-dev \
+  libpapi-dev \
+  mpich \
+  libomp-dev \
+  libomp5 \
+  python3-pip
+
+RUN add-apt-repository ppa:geopm/release \
+  && apt-get update \
+  && apt-get install -y \
+  geopm-service \
+  libgeopmd-dev \
+  libgeopmd2 \
+  python3-geopmdpy
+
+WORKDIR /app
+RUN cd /app \
+  && git clone https://github.com/bats-core/bats-core.git \
+  && cd /app/bats-core \
+  && ./install.sh /usr
+
+RUN cd /app \
+  && git clone https://github.com/anlsys/libnrm.git \
+  && cd /app/libnrm \
+  && git checkout feature/prometheus-exporter \
+  && ./autogen.sh \
+  && ./configure --prefix=/usr --with-python --with-geopm \
+  && make -j \
+  && make install
+
+COPY requirements.txt /app/
+RUN pip3 install -r /app/requirements.txt
+
+COPY nrm-k3s.py /app/
+ENV PYTHONPATH=/usr/lib/python3.10/site-packages:$PYTHONPATH
+ENTRYPOINT ["nrmd"]

--- a/src/nrm_docker/README.md
+++ b/src/nrm_docker/README.md
@@ -1,0 +1,21 @@
+# NRM in a container
+This directory holds some resources to create and use NRM in a container.
+
+# Building NRM container
+To build a container of NRM, run,
+
+```bash
+docker build -t charon/nrm .
+```
+
+# Running NRM container
+
+```bash
+docker run -d --network host -p 2345:2345 -p 3456:3456 charon/nrm
+```
+
+# Running NRM-k3s container
+
+```bash
+docker run -ti --rm --network host --entrypoint python3 charon/nrm /app/nrm-k3s.py --debug
+```

--- a/src/nrm_docker/nrm-k3s.py
+++ b/src/nrm_docker/nrm-k3s.py
@@ -1,0 +1,135 @@
+import argparse
+import logging
+import time
+from multiprocessing import Process, Queue
+import os
+
+from kubernetes import client, config, watch
+import nrm
+
+
+def pull_pods(args):
+    logging.info("Pod worker starts...")
+    config.load_incluster_config()
+    nrmc = nrm.Client(args.nrm_uri)
+    v1 = client.CoreV1Api()
+    w = watch.Watch()
+    for event in w.stream(
+        v1.list_namespaced_pod,
+        args.namespace,
+        timeout_seconds=3600):
+        # _request_timeout closes the connection in the undesirable way
+        # as we want to keep events coming. We should not set the value.
+        # _request_timeout=60):
+        event_type = event["type"]
+        # logging.debug(f'Pod worker Event:{event_type}, {event}')
+        pod_name = event["object"].metadata.name
+        if event_type == "ADDED":
+            cpu_sensor = f'{pod_name}.cpuutil'
+            memory_sensor = f'{pod_name}.membytes'
+            nrmc.add_sensor(cpu_sensor)
+            logging.info(f'Sensor {cpu_sensor} added')
+            nrmc.add_sensor(memory_sensor)
+            logging.info(f'Sensor {memory_sensor} added')
+        elif event_type == "DELETED":
+            # do we need to delete the sensor in NRM?
+            logging.info(f'Sensor {pod_name} deleted')
+    logging.error("Pod worker closed")
+
+
+def parse_cpu(cpu_metric):
+    value = int(cpu_metric[:-1])
+    unit = cpu_metric[-1]
+
+    if unit == 'n':
+        return value / 1e6
+    else:
+        return value
+
+
+def parse_memory(memory_metric):
+    value = int(memory_metric[:-2])
+    unit = memory_metric[-2:]
+
+    if unit == "Ki":
+        return value * 1024
+    else:
+        return value
+
+
+def pull_pod_metrics(args):
+    logging.info("Pod metric worker starts...")
+    config.load_incluster_config()
+    cust = client.CustomObjectsApi()
+    nrmc = nrm.Client(args.nrm_uri)
+    allscope = nrmc.list_scopes()[0]
+
+    while True:
+        pod_metrics = cust.list_namespaced_custom_object(
+            'metrics.k8s.io', 'v1beta1', args.namespace, 'pods')
+        for pod_metric in pod_metrics["items"]:
+            # logging.debug(f'Pod metric worker:, {pod_metric}')
+            now = nrm.nrm_time_fromns(time.time_ns())
+            pod_name = pod_metric["metadata"]["name"]
+            cpu_sensor = nrmc.add_sensor(f'{pod_name}.cpuutil')
+            memory_sensor = nrmc.add_sensor(f'{pod_name}.membytes')
+            pod_cpu = parse_cpu(pod_metric["containers"][0]["usage"]["cpu"])
+            pod_memory = parse_memory(pod_metric["containers"][0]["usage"]["memory"])
+            logging.debug(f'Publishing Pod {pod_name} metric: {pod_cpu}, {pod_memory}')
+            nrmc.send_event(now, cpu_sensor, allscope.ptr, pod_cpu)
+            nrmc.send_event(now, memory_sensor, allscope.ptr, pod_memory)
+            logging.debug(f'Published')
+            
+        time.sleep(args.interval)
+
+
+def main(args):
+    logging.info("configurations")
+    logging.info(f'interval: {args.interval}')
+    logging.info(f'namespace to watch: {args.namespace}')
+    
+    pod_worker = Process(target=pull_pods, args=(args,))
+    pod_metric_worker = Process(target=pull_pod_metrics, args=(args,))
+    
+    db = dict()
+    try:
+        # NOTE: pod_metric_worker adds sensors for workloads.
+        #       Unless we need to remove sensors we don't need to run
+        #       pod_worker which will add/remove sensors
+        # pod_worker.start()
+        pod_metric_worker.start()
+        while True:
+            time.sleep(args.interval)
+    except Exception as ex:
+        logging.error(f'{str(ex)}')
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # we need to clean up workers
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--debug", dest="debug",
+        action="store_true",
+        help="Enable debugging")
+    parser.add_argument('-u', '--nrm-uri',
+        action='store', dest='nrm_uri', type=str,
+        default=os.getenv("NRM_URI", "tcp://nrm"), help='URI to NRM daemon')
+    parser.add_argument('--interval',
+        action='store', dest='interval', type=int,
+        default=1, help='Interval in seconds for publishing')
+    parser.add_argument('-n', '--namespace',
+        action='store', dest='namespace', type=str,
+        default="workload", help='Interval in seconds for publishing')
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s',
+        datefmt='%Y/%m/%d %H:%M:%S')
+
+    exit(main(args))

--- a/src/nrm_docker/nrm-k3s.py.backup
+++ b/src/nrm_docker/nrm-k3s.py.backup
@@ -1,0 +1,133 @@
+import argparse
+import logging
+import time
+from multiprocessing import Process, Queue
+
+from kubernetes import client, config, watch
+import nrm
+
+
+def pull_pods(args, out_queue):
+    logging.info("Pod worker starts...")
+    config.load_incluster_config()
+    v1 = client.CoreV1Api()
+    w = watch.Watch()
+    for event in w.stream(
+        v1.list_namespaced_pod,
+        args.namespace,
+        timeout_seconds=3600):
+        # _request_timeout closes the connection in the undesirable way
+        # as we want to keep events coming. We should not set the value.
+        # _request_timeout=60):
+        event_type = event["type"]
+        message = {
+            "name": event["object"].metadata.name
+        } 
+        logging.debug(f'Pod worker Event:{event_type}, {message}')
+        out_queue.put((event_type, message))
+    logging.error("Pod worker closed")
+
+
+def parse_cpu(cpu_metric):
+    value = int(cpu_metric[:-1])
+    unit = cpu_metric[-1]
+
+    if unit == 'n':
+        return value / 1e-6
+
+
+def parse_memory(memory_metric):
+    value = int(memory_metric[:-2])
+    unit = memory_metric[-2:]
+
+    if unit == "Ki":
+        return value * 1024
+
+
+def pull_pod_metrics(args, out_queue):
+    logging.info("Pod metric worker starts...")
+    config.load_incluster_config()
+    cust = client.CustomObjectsApi()
+    event_type = "UPDATED"
+
+    while True:
+        pod_metrics = cust.list_namespaced_custom_object(
+            'metrics.k8s.io', 'v1beta1', args.namespace, 'pods')
+        for pod_metric in pod_metrics["items"]:
+            message = {
+                "name": pod_metric["metadata"]["name"],
+                "cpu": parse_cpu(pod_metric["containers"][0]["usage"]["cpu"]),
+                "memory": parse_memory(pod_metric["containers"][0]["usage"]["memory"]),
+            }
+            logging.debug(f'Pod metric worker Event:{event_type}, {message}')
+            out_queue.put((event_type, message))
+        time.sleep(args.interval)
+
+
+def main(args):
+    logging.info("configurations")
+    logging.info(f'interval: {args.interval}')
+    logging.info(f'namespace to watch: {args.namespace}')
+    queue = Queue()
+    pod_worker = Process(target=pull_pods, args=(args, queue))
+    pod_metric_worker = Process(target=pull_pod_metrics, args=(args, queue))
+    c = nrm.Client(args.nrm_uri)
+    allscope = c.list_scopes()[0]
+    db = dict()
+    try:
+        pod_worker.start()
+        pod_metric_worker.start()
+        while True:
+            try:
+                message_type, message = queue.get(block=False)
+            except Queue: 
+            if message_type is not None:
+                logging.debug(f'Received: {message}')
+                cpu_sensor = f'{message["name"]}.cpuutil'
+                memory_sensor = f'{message["name"]}.membytes'
+                if message_type == "UPDATED":
+                    now = nrm.nrm_time_fromns(time.time_ns())
+                    c.send_event(now, cpu_sensor, allscope, message["cpu"])
+                    c.send_event(now, memory_sensor, allscope, message["memory"])
+                elif message_type == "ADDED":
+                    c.add_sensor(cpu_sensor)
+                    logging.info(f'Sensor {cpu_sensor} added')
+                    c.add_sensor(memory_sensor)
+                    logging.info(f'Sensor {memory_sensor} added')
+                elif message_type == "DELETED":
+                    # do we need to delete the sensor in NRM?
+                    logging.info(f'Sensor {message["name"]} deleted')
+            time.sleep(args.interval)
+    except Exception as ex:
+        logging.error(f'{str(ex)}')
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # we need to clean up workers
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--debug", dest="debug",
+        action="store_true",
+        help="Enable debugging")
+    parser.add_argument('-u', '--nrm-uri',
+        action='store', dest='nrm_uri', type=str,
+        default="tcp://nrm", help='URI to NRM daemon')
+    parser.add_argument('--interval',
+        action='store', dest='interval', type=int,
+        default=1, help='Interval in seconds for publishing')
+    parser.add_argument('-n', '--namespace',
+        action='store', dest='namespace', type=str,
+        default="workload", help='Interval in seconds for publishing')
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s',
+        datefmt='%Y/%m/%d %H:%M:%S')
+
+    exit(main(args))

--- a/src/nrm_docker/requirements.txt
+++ b/src/nrm_docker/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes


### PR DESCRIPTION
- Added NRMD container along with the Kubernetes object file.
- Added nrm-k3s that scrapes resource metrics of workloads and publishes them to NRMD.

NOTE: The NRMD is also exposed on the host machine where the NRMD container runs. You can tap into NRM event stream by `nrmc listen` on the host.